### PR TITLE
GTG-41: Error in traverseTree function for one month run

### DIFF
--- a/code/baselineTiming.py
+++ b/code/baselineTiming.py
@@ -3,9 +3,11 @@
 '''
 import unittest
 import time
+import sys
+import subprocess
 
 import networkx as nx
-import subprocess
+
 
 import iomethods
 import mccSearch
@@ -13,6 +15,8 @@ import utils
 
 
 def main():
+    sys.setrecursionlimit(5000)
+
     CEGraph = nx.DiGraph()
     prunedGraph = nx.DiGraph()
     MCCList =[]

--- a/code/mainProgTemplate.py
+++ b/code/mainProgTemplate.py
@@ -1,9 +1,10 @@
 '''
 # running the program
 '''
+import sys
+import subprocess
 
 import networkx as nx
-import subprocess
 
 import iomethods
 import mccSearch
@@ -11,6 +12,8 @@ import utils
 
 
 def main():
+    sys.setrecursionlimit(5000)
+
     CEGraph = nx.DiGraph()
     prunedGraph = nx.DiGraph()
     MCCList =[]

--- a/code/mccSearchUI.py
+++ b/code/mccSearchUI.py
@@ -4,6 +4,7 @@
 
 import os
 import subprocess
+import sys
 
 import networkx as nx
 
@@ -14,7 +15,10 @@ import plotting
 import metrics
 import iomethods
 
+
 def main():
+    sys.setrecursionlimit(5000)
+
     CEGraph = nx.DiGraph()
     prunedGraph = nx.DiGraph()
     MCCList =[]


### PR DESCRIPTION
- increased python's default recursive limit
- increased the max recursive depth x5 as default in GTG 
