### PR TITLE
MERG and TRMM timings were exactly the same

### DIFF
--- a/code/baselineTiming.py
+++ b/code/baselineTiming.py
@@ -124,13 +124,15 @@ def main():
     print "\n End the timer for findCloudElements process using MERG only"
     print "\n Total time to complete finding cloud elements in MERG only is %g seconds"%(findCEsEnd - findCEsStart)
     unittestFile.write("\n Total time to complete finding cloud elements in MERG only is %g seconds"%(findCEsEnd - findCEsStart))
+    
+    # *** TRMM DATA SET TIMINGS *** 
     print "\n Start the timer for findCloudElements process using TRMM only"
     findCETRMMStart = time.time()
     allCETRMMList = mccSearch.find_precip_rate(DIRS['TRMMdirName'],timeList)
     findCETRMMEnd = time.time()
     print "\n End the timer for findCloudElements process using TRMM only"
-    print "\n Total time to complete finding cloud elements in TRMM only is %g seconds"%(findCEsEnd - findCEsStart)
-    unittestFile.write("\n Total time to complete finding cloud elements in TRMM only is %g seconds"%(findCEsEnd - findCEsStart))
+    print "\n Total time to complete finding cloud elements in TRMM only is %g seconds"%(findCETRMMEnd - findCETRMMStart)
+    unittestFile.write("\n Total time to complete finding cloud elements in TRMM only is %g seconds"%(findCETRMMEnd - findCETRMMStart))
     print "\n Number of cloud elements found is: ", CEGraph.number_of_nodes()
     print "\n Total time to complete finding cloud elements is %g seconds"%(findCETRMMEnd - findCEsStart)
     unittestFile.write("\n Total time to complete finding cloud elements is %g seconds"%(findCETRMMEnd - findCEsStart))


### PR DESCRIPTION
I noticed the MERG and TRMM dataset timings were exactly the same in the unittest results.  Finally dug into why and correct it.
